### PR TITLE
[Mittel] Härtung: HTTP-Timeout und defensive Wertprüfung

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,6 +1,10 @@
 framework:
     secret: '%env(APP_SECRET)%'
     http_method_override: false
+    http_client:
+        default_options:
+            timeout: 10
+            max_duration: 30
     php_errors:
         log: true
 

--- a/src/SourceFetcher/Parser/Parser.php
+++ b/src/SourceFetcher/Parser/Parser.php
@@ -24,7 +24,8 @@ class Parser implements ParserInterface
 
         foreach ($response['data'] as $ubaStationId => $dataSet) {
             while ($data = array_pop($dataSet)) {
-                if ($data[2] <= 0) {
+                // Remote-Wert defensiv prüfen: nur numerische, endliche, positive Werte.
+                if (!is_numeric($data[2]) || !is_finite((float) $data[2]) || (float) $data[2] <= 0) {
                     continue;
                 }
 


### PR DESCRIPTION
Adressiert den Härtungs-Teil von #51 (Dependency-Updates separat — siehe Hinweis).

## Änderungen
- **`config/packages/framework.yaml`**: `http_client.default_options.timeout: 10` + `max_duration: 30`. Bisher kein Timeout — bei hängender UBA-API blockiert der Cron-Job.
- **`SourceFetcher/Parser/Parser`**: Remote-Messwert wird vor der Übernahme auf `is_numeric` + `is_finite` geprüft (zuvor nur `<= 0`). Verhindert, dass nicht-numerische oder `NaN`/`Inf`-Werte aus fehlerhaften API-Antworten in die luft-app-Datenbank gelangen.

## Verifikation
`php -l` ok, Test-Suite grün (68 Tests). Die bestehende Eingabevalidierung (Pollutant-Enum via `tryFrom`, Stationstyp-`match`, `<= 0`-Filter) bleibt erhalten.

## Hinweis (separat)
Die Symfony-Dependency-CVEs aus #51 erfordern denselben koordinierten Symfony-8.1-/PHPStan-Schritt wie luft-app#525.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)