### PR TITLE
Fix timezone offset in UBA query and response handling (#53)

### DIFF
--- a/src/SourceFetcher/Parser/Parser.php
+++ b/src/SourceFetcher/Parser/Parser.php
@@ -8,6 +8,12 @@ use Caldera\LuftModel\Model\Value;
 
 class Parser implements ParserInterface
 {
+    /**
+     * The UBA JSON API reports all timestamps in MEZ (CET, UTC+1, without daylight
+     * saving time). See the official interface description of the Luftdaten API.
+     */
+    private const UBA_TIMEZONE = '+01:00';
+
     /** @var array<int, Station> */
     protected array $stationList;
 
@@ -39,7 +45,7 @@ class Parser implements ParserInterface
 
                 $value
                     ->setStationCode($station->getStationCode())
-                    ->setDateTime(new \DateTime($data[3]))
+                    ->setDateTime(new \DateTime($data[3], new \DateTimeZone(self::UBA_TIMEZONE)))
                     ->setPollutant($pollutant)
                     ->setValue($data[2]);
 

--- a/src/SourceFetcher/QueryBuilder/QueryBuilder.php
+++ b/src/SourceFetcher/QueryBuilder/QueryBuilder.php
@@ -6,6 +6,13 @@ use App\SourceFetcher\Query\Query;
 
 class QueryBuilder
 {
+    /**
+     * The UBA JSON API expects and reports all timestamps in MEZ (CET, UTC+1,
+     * without daylight saving time). Query times must therefore be converted to
+     * this fixed offset before formatting, regardless of the server timezone.
+     */
+    private const UBA_TIMEZONE = '+01:00';
+
     protected function __construct()
     {
     }
@@ -13,13 +20,17 @@ class QueryBuilder
     /** @return array<string, int|string> */
     public static function buildQueryParameters(Query $query): array
     {
+        $timezone = new \DateTimeZone(self::UBA_TIMEZONE);
+        $fromDateTime = $query->fromDateTime->setTimezone($timezone);
+        $untilDateTime = $query->untilDateTime->setTimezone($timezone);
+
         return [
             'component' => $query->pollutant->component(),
             'scope' => $query->pollutant->scope(),
-            'date_from' => $query->fromDateTime->format('Y-m-d'),
-            'time_from' => ((int) $query->fromDateTime->format('H') + 1),
-            'date_to' => $query->untilDateTime->format('Y-m-d'),
-            'time_to' => ((int) $query->untilDateTime->format('H') + 1),
+            'date_from' => $fromDateTime->format('Y-m-d'),
+            'time_from' => ((int) $fromDateTime->format('H') + 1),
+            'date_to' => $untilDateTime->format('Y-m-d'),
+            'time_to' => ((int) $untilDateTime->format('H') + 1),
         ];
     }
 }

--- a/tests/SourceFetcher/Parser/ParserExtendedTest.php
+++ b/tests/SourceFetcher/Parser/ParserExtendedTest.php
@@ -91,6 +91,30 @@ class ParserExtendedTest extends TestCase
         $this->assertSame('2024-12-25 18:30:00', $result[0]->getDateTime()->format('Y-m-d H:i:s'));
     }
 
+    public function testParseInterpretsTimestampsAsMez(): void
+    {
+        $stations = [100 => $this->createStation('DEBW001')];
+        $parser = new Parser($this->createManager($stations));
+
+        $response = json_encode([
+            'data' => [
+                100 => [[100, 1, 42.0, '2024-12-25 18:30:00']],
+            ],
+        ]);
+
+        $result = $parser->parse($response, 'o3');
+
+        $dateTime = $result[0]->getDateTime();
+
+        // The UBA JSON API reports MEZ (UTC+1) timestamps.
+        $this->assertSame(3600, $dateTime->getOffset());
+        // The same instant expressed in UTC is one hour earlier.
+        $this->assertSame(
+            '2024-12-25 17:30:00',
+            $dateTime->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+        );
+    }
+
     public function testParseMixesValidAndInvalidValues(): void
     {
         $stations = [

--- a/tests/SourceFetcher/QueryBuilder/QueryBuilderTest.php
+++ b/tests/SourceFetcher/QueryBuilder/QueryBuilderTest.php
@@ -11,8 +11,8 @@ class QueryBuilderTest extends TestCase
 {
     public function testBuildQueryParametersWithValidQuery(): void
     {
-        $from = new \DateTimeImmutable('2024-06-15 10:00:00');
-        $until = new \DateTimeImmutable('2024-06-15 12:00:00');
+        $from = new \DateTimeImmutable('2024-06-15 10:00:00', new \DateTimeZone('+01:00'));
+        $until = new \DateTimeImmutable('2024-06-15 12:00:00', new \DateTimeZone('+01:00'));
         $query = new Query(Pollutant::PM10, $until, $from);
 
         $params = QueryBuilder::buildQueryParameters($query);
@@ -27,8 +27,8 @@ class QueryBuilderTest extends TestCase
 
     public function testTimeOffsetByOne(): void
     {
-        $from = new \DateTimeImmutable('2024-06-15 00:00:00');
-        $until = new \DateTimeImmutable('2024-06-15 23:00:00');
+        $from = new \DateTimeImmutable('2024-06-15 00:00:00', new \DateTimeZone('+01:00'));
+        $until = new \DateTimeImmutable('2024-06-15 23:00:00', new \DateTimeZone('+01:00'));
         $query = new Query(Pollutant::NO2, $until, $from);
 
         $params = QueryBuilder::buildQueryParameters($query);
@@ -45,5 +45,33 @@ class QueryBuilderTest extends TestCase
 
         $this->assertSame(2, $params['component']);
         $this->assertSame(4, $params['scope']);
+    }
+
+    public function testQueryTimesAreConvertedToMezRegardlessOfInputTimezone(): void
+    {
+        // 10:00 UTC is 11:00 in MEZ (UTC+1), which the +1 offset turns into 12.
+        $from = new \DateTimeImmutable('2024-06-15 10:00:00', new \DateTimeZone('UTC'));
+        $until = new \DateTimeImmutable('2024-06-15 12:00:00', new \DateTimeZone('UTC'));
+        $query = new Query(Pollutant::PM10, $until, $from);
+
+        $params = QueryBuilder::buildQueryParameters($query);
+
+        $this->assertSame('2024-06-15', $params['date_from']);
+        $this->assertSame(12, $params['time_from']);
+        $this->assertSame('2024-06-15', $params['date_to']);
+        $this->assertSame(14, $params['time_to']);
+    }
+
+    public function testDayBoundaryIsHandledInMez(): void
+    {
+        // 23:30 UTC is 00:30 MEZ on the next day.
+        $from = new \DateTimeImmutable('2024-06-15 23:30:00', new \DateTimeZone('UTC'));
+        $until = new \DateTimeImmutable('2024-06-15 23:30:00', new \DateTimeZone('UTC'));
+        $query = new Query(Pollutant::PM10, $until, $from);
+
+        $params = QueryBuilder::buildQueryParameters($query);
+
+        $this->assertSame('2024-06-16', $params['date_from']);
+        $this->assertSame(1, $params['time_from']);
     }
 }

--- a/tests/SourceFetcher/SourceFetcherTest.php
+++ b/tests/SourceFetcher/SourceFetcherTest.php
@@ -35,8 +35,8 @@ class SourceFetcherTest extends TestCase
 
     public function testFetchUsesProvidedDates(): void
     {
-        $from = new \DateTimeImmutable('2024-06-15 10:00:00');
-        $until = new \DateTimeImmutable('2024-06-15 12:00:00');
+        $from = new \DateTimeImmutable('2024-06-15 10:00:00', new \DateTimeZone('+01:00'));
+        $until = new \DateTimeImmutable('2024-06-15 12:00:00', new \DateTimeZone('+01:00'));
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getContent')->willReturn('{"data":{}}');


### PR DESCRIPTION
## Summary

The UBA JSON API reports and expects all timestamps in **MEZ** (CET, UTC+1, without daylight saving time). The code formatted query times and parsed response timestamps in the server's default timezone, so every measurement pushed to luft.jetzt was off by one hour on a UTC server (year round) or in summer on an `Europe/Berlin` server. Both defects were silent — the command still reported success.

Verified live against the current API (`https://luftdaten.umweltbundesamt.de/api/air-data/v4/measures/json`): the newest `date end` values are consistent with MEZ semantics, matching the official interface description.

## Changes

- `QueryBuilder::buildQueryParameters()` converts `from`/`until` to `+01:00` before formatting `date_from`/`time_from`/`date_to`/`time_to`.
- `Parser::parse()` parses the response `date end` field with an explicit `+01:00` timezone, so the stored instant is correct regardless of server timezone.
- Existing `QueryBuilder`/`SourceFetcher` tests were pinned to explicit offsets to make them timezone-deterministic; regression tests added for the MEZ conversion (both directions) and day-boundary handling.

## Already fixed on main (not re-done here)

- The **Carbon in-place mutation** bug described in the issue (the 2h window collapsing to a single point) is already resolved: the code uses `\DateTimeImmutable`, whose `sub()` returns a new instance. `SourceFetcher::fetch()` therefore produces a proper `[now-2h, now]` window. A regression test for this already exists (`SourceFetcherTest::testFetchDefaultsToTwoHourRange`).

## Deliberately not implemented

- **Widening the default window to 3–6h overlapping** to self-heal missed cron runs. This is a behavioral/operational change to a deliberate default rather than a correctness fix; left to the maintainers to decide. The mutation fix already restores the intended 2h window.

## Verification

- `vendor/bin/phpunit` green under both `TZ=UTC` and `TZ=Europe/Berlin` (71 tests).
- `vendor/bin/phpstan analyse` reports no errors.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)