### PR TITLE
Harden UBA fetch path: v4 endpoint, JSON errors, observable cache misses, cache DI (#55)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,3 +21,16 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    # The station cache uses a dedicated filesystem pool (its own namespace and
+    # 1h TTL) injected explicitly, rather than instantiating the adapter itself.
+    App\StationCache\StationCache:
+        arguments:
+            $cache: '@app.station_cache.adapter'
+
+    app.station_cache.adapter:
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            $namespace: !php/const App\StationCache\StationCacheInterface::NAMESPACE
+            $defaultLifetime: !php/const App\StationCache\StationCacheInterface::TTL
+            $directory: '%kernel.project_dir%/var/cache/'

--- a/src/Command/LuftFetchCommand.php
+++ b/src/Command/LuftFetchCommand.php
@@ -72,6 +72,14 @@ class LuftFetchCommand extends Command
 
             $valueList = $this->parser->parse($dataString, $pollutant->value);
 
+            $skippedCount = $this->parser->getSkippedStationValueCount();
+
+            if ($skippedCount > 0 && count($valueList) === 0) {
+                $io->warning(sprintf('All %d fetched value(s) for pollutant "%s" were dropped because their stations are not in the cache. Run "station:cache" (the cache has a 1h TTL).', $skippedCount, $pollutant->value));
+            } elseif ($skippedCount > 0) {
+                $io->note(sprintf('Skipped %d value(s) for pollutant "%s" because their stations are not in the cache.', $skippedCount, $pollutant->value));
+            }
+
             if ($tag = $input->getOption('tag')) {
                 foreach ($valueList as $value) {
                     $value->setTag($tag);

--- a/src/SourceFetcher/Parser/Parser.php
+++ b/src/SourceFetcher/Parser/Parser.php
@@ -11,6 +11,13 @@ class Parser implements ParserInterface
     /** @var array<int, Station> */
     protected array $stationList;
 
+    /**
+     * Number of measurements skipped during the last parse() run because their
+     * station was not present in the station cache (cache miss). Exposed so the
+     * caller can make the otherwise silent data loss observable.
+     */
+    private int $skippedStationValueCount = 0;
+
     public function __construct(protected readonly StationManagerInterface $stationManager)
     {
     }
@@ -18,7 +25,17 @@ class Parser implements ParserInterface
     /** @return list<Value> */
     public function parse(string $responseString, string $pollutant): array
     {
-        $response = json_decode($responseString, true, 512, JSON_OBJECT_AS_ARRAY);
+        $this->skippedStationValueCount = 0;
+
+        try {
+            $response = json_decode($responseString, true, 512, JSON_THROW_ON_ERROR | JSON_OBJECT_AS_ARRAY);
+        } catch (\JsonException $exception) {
+            throw new \RuntimeException(sprintf('Failed to decode UBA response as JSON: %s', $exception->getMessage()), 0, $exception);
+        }
+
+        if (!is_array($response) || !array_key_exists('data', $response) || !is_array($response['data'])) {
+            throw new \RuntimeException('Unexpected UBA response: missing or invalid "data" key.');
+        }
 
         $valueList = [];
 
@@ -29,6 +46,8 @@ class Parser implements ParserInterface
                 }
 
                 if (!$this->stationManager->stationExists($ubaStationId)) {
+                    ++$this->skippedStationValueCount;
+
                     continue;
                 }
 
@@ -48,5 +67,14 @@ class Parser implements ParserInterface
         }
 
         return $valueList;
+    }
+
+    /**
+     * Number of measurements dropped in the last parse() run because their
+     * station was not found in the cache.
+     */
+    public function getSkippedStationValueCount(): int
+    {
+        return $this->skippedStationValueCount;
     }
 }

--- a/src/SourceFetcher/Parser/ParserInterface.php
+++ b/src/SourceFetcher/Parser/ParserInterface.php
@@ -6,4 +6,10 @@ interface ParserInterface
 {
     /** @return list<\Caldera\LuftModel\Model\Value> */
     public function parse(string $responseString, string $pollutant): array;
+
+    /**
+     * Number of measurements dropped in the last parse() run because their
+     * station was not found in the cache.
+     */
+    public function getSkippedStationValueCount(): int;
 }

--- a/src/SourceFetcher/SourceFetcher.php
+++ b/src/SourceFetcher/SourceFetcher.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class SourceFetcher implements SourceFetcherInterface
 {
-    private const API_URL = 'https://www.umweltbundesamt.de/api/air_data/v2/measures/json';
+    private const API_URL = 'https://luftdaten.umweltbundesamt.de/api/air-data/v4/measures/json';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,

--- a/src/StationCache/StationCache.php
+++ b/src/StationCache/StationCache.php
@@ -3,15 +3,16 @@
 namespace App\StationCache;
 
 use Caldera\LuftModel\Model\Station;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 class StationCache implements StationCacheInterface
 {
-    private readonly FilesystemAdapter $cache;
+    private readonly CacheItemPoolInterface $cache;
 
-    public function __construct()
+    public function __construct(?CacheItemPoolInterface $cache = null)
     {
-        $this->cache = new FilesystemAdapter(self::NAMESPACE, self::TTL, self::CACHE_DIRECTORY);
+        $this->cache = $cache ?? new FilesystemAdapter(self::NAMESPACE, self::TTL, self::CACHE_DIRECTORY);
     }
 
     public function addStation(Station $station): self

--- a/src/StationLoader/StationLoader.php
+++ b/src/StationLoader/StationLoader.php
@@ -8,7 +8,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class StationLoader implements StationLoaderInterface
 {
-    const SOURCE_URL = 'https://www.umweltbundesamt.de/api/air_data/v2/meta/json?use=measure&lang=de';
+    const SOURCE_URL = 'https://luftdaten.umweltbundesamt.de/api/air-data/v4/meta/json?use=measure&lang=de';
 
     const PROVIDER_IDENTIFIER = 'uba_de';
 

--- a/tests/SourceFetcher/Parser/ParserTest.php
+++ b/tests/SourceFetcher/Parser/ParserTest.php
@@ -113,4 +113,58 @@ class ParserTest extends TestCase
 
         $this->assertCount(0, $result);
     }
+
+    public function testParseInvalidJsonThrows(): void
+    {
+        $parser = $this->createParser($this->createStationManager());
+
+        $this->expectException(\RuntimeException::class);
+
+        $parser->parse('<html>Service Unavailable</html>', 'pm10');
+    }
+
+    public function testParseMissingDataKeyThrows(): void
+    {
+        $parser = $this->createParser($this->createStationManager());
+
+        $this->expectException(\RuntimeException::class);
+
+        $parser->parse(json_encode(['request' => []]), 'pm10');
+    }
+
+    public function testSkippedStationValueCountTracksCacheMisses(): void
+    {
+        $parser = $this->createParser($this->createStationManager(false));
+
+        $response = json_encode([
+            'data' => [
+                999 => [
+                    [999, 1, 42.5, '2024-06-15 12:00:00'],
+                    [999, 1, 43.5, '2024-06-15 13:00:00'],
+                ],
+            ],
+        ]);
+
+        $result = $parser->parse($response, 'pm10');
+
+        $this->assertCount(0, $result);
+        $this->assertSame(2, $parser->getSkippedStationValueCount());
+    }
+
+    public function testSkippedStationValueCountResetsBetweenRuns(): void
+    {
+        $parser = $this->createParser($this->createStationManager(false));
+
+        $response = json_encode([
+            'data' => [
+                999 => [[999, 1, 42.5, '2024-06-15 12:00:00']],
+            ],
+        ]);
+
+        $parser->parse($response, 'pm10');
+        $this->assertSame(1, $parser->getSkippedStationValueCount());
+
+        $parser->parse(json_encode(['data' => []]), 'pm10');
+        $this->assertSame(0, $parser->getSkippedStationValueCount());
+    }
 }

--- a/tests/StationCache/StationCacheTest.php
+++ b/tests/StationCache/StationCacheTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\StationCache;
 use App\StationCache\StationCache;
 use Caldera\LuftModel\Model\Station;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 
 class StationCacheTest extends TestCase
@@ -73,5 +74,22 @@ class StationCacheTest extends TestCase
 
         $retrieved = $this->cache->getStationByUbaStationId(42);
         $this->assertSame('NEW', $retrieved->getStationCode());
+    }
+
+    public function testUsesInjectedCachePool(): void
+    {
+        $cache = new StationCache(new ArrayAdapter());
+
+        $station = new Station();
+        $station->setUbaStationId(7);
+        $station->setStationCode('DEBB007');
+
+        $cache->addStation($station);
+
+        $retrieved = $cache->getStationByUbaStationId(7);
+
+        $this->assertNotNull($retrieved);
+        $this->assertSame('DEBB007', $retrieved->getStationCode());
+        $this->assertNull($cache->getStationByUbaStationId(999));
     }
 }


### PR DESCRIPTION
## Summary

Hardens the fetch path — the core purpose of this service — which previously could not distinguish "no data", "UBA down", and "response format changed".

## Changes

- **Current v4 endpoint.** Both URLs (`SourceFetcher::API_URL`, `StationLoader::SOURCE_URL`) move from the deprecated `www.umweltbundesamt.de/api/air_data/v2/...` host to `luftdaten.umweltbundesamt.de/api/air-data/v4/...`. The old host only answers with a **301** to the new one. Verified live against the current API that the response format is byte-for-byte compatible (`data → stationId → dateStart → [componentId, scopeId, value, dateEnd, index]`, and `meta/json` station rows), so the existing parser and field mapping keep working.
- **JSON error handling.** `Parser::parse()` decodes with `JSON_THROW_ON_ERROR` and asserts the `data` key exists and is an array, so an HTML error page or truncated response raises a clear `RuntimeException` instead of a `foreach (null[...])` crash.
- **Observable cache misses.** `Parser` counts measurements dropped because their station is not in the cache (`getSkippedStationValueCount()`); `luft:fetch` prints a note, or a **warning** when 100% of a pollutant's values are dropped — the tell-tale of a stale station cache (TTL 1h) that previously reported "Fetched 0 values" as success.
- **Cache injection.** `StationCache` accepts an injected PSR-6 pool instead of `new FilesystemAdapter(...)` in its constructor. `services.yaml` wires a dedicated filesystem pool with the **same** namespace/TTL/directory, so production behavior is unchanged; tests now use an `ArrayAdapter`. The no-arg constructor still falls back to the original adapter.

## Already resolved on main (not re-done here)

- **Magic numbers / dynamic dispatch.** Component/scope IDs are already a documented `Pollutant` enum with `component()`/`scope()` `match` methods; the old `sprintf('fetch%s')` + `method_exists` dispatch is gone.
- **`mapAreaType`/`mapStationType`** already use `match` with a default that throws an exception naming the unknown value.
- **HTTP-client migration.** `file_get_contents` is already replaced by `symfony/http-client` in both classes (whose `getContent()`/`toArray()` throw on non-2xx / invalid JSON).

## Deliberately not implemented

- **Timeout and value/coordinate plausibility validation.** Per this issue's own scope note, those belong to #51 and are handled there.
- **PM2.5 (component 9)** support — flagged as an open product question in the issue, not a defect.

## Verification

- `vendor/bin/phpunit` green (73 tests; new tests for JSON errors, the skip counter, and `ArrayAdapter` injection).
- `vendor/bin/phpstan analyse` → no errors.
- `bin/console debug:container App\StationCache\StationCache` confirms the injected `app.station_cache.adapter`.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)