### PR TITLE
StationLoader: reachable update path, skip decommissioned stations, drop dead code (#56)

### DIFF
--- a/src/Command/StationLoadCommand.php
+++ b/src/Command/StationLoadCommand.php
@@ -7,6 +7,7 @@ use Caldera\LuftApiBundle\Api\StationApiInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -21,9 +22,18 @@ class StationLoadCommand extends Command
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        $this
+            ->addOption('update', null, InputOption::VALUE_NONE, 'Also merge and re-submit stations that already exist in the luft.jetzt database')
+        ;
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        $this->stationLoader->setUpdate((bool) $input->getOption('update'));
 
         $result = $this->stationLoader->load();
 

--- a/src/StationLoader/StationLoader.php
+++ b/src/StationLoader/StationLoader.php
@@ -15,12 +15,10 @@ class StationLoader implements StationLoaderInterface
     const FIELD_ID = 0;
     const FIELD_STATION_CODE = 1;
     const FIELD_TITLE = 2;
-    const FIELD_CITY = 3;
     const FIELD_START_DATE = 5;
+    const FIELD_ACTIVE_TO = 6;
     const FIELD_LONGITUDE = 7;
     const FIELD_LATITUDE = 8;
-    const FIELD_STATE_CODE = 12;
-    const FIELD_STATE = 13;
     const FIELD_AREA_TYPE = 15;
     const FIELD_STATION_TYPE = 16;
 
@@ -45,7 +43,7 @@ class StationLoader implements StationLoaderInterface
     {
         $station
             ->setTitle($stationData[self::FIELD_TITLE])
-            ->setProvider('uba_de')
+            ->setProvider(self::PROVIDER_IDENTIFIER)
             ->setStationCode($stationData[self::FIELD_STATION_CODE])
             ->setLatitude((float)$stationData[self::FIELD_LATITUDE])
             ->setLongitude((float)$stationData[self::FIELD_LONGITUDE])
@@ -67,6 +65,13 @@ class StationLoader implements StationLoaderInterface
 
         foreach ($this->ubaStationList as $stationData) {
             if (!array_key_exists(self::FIELD_STATION_CODE, $stationData) || !$stationData[self::FIELD_STATION_CODE]) {
+                continue;
+            }
+
+            // Field 6 ("active to") is null/empty for stations still in operation
+            // and holds a decommissioning date for retired stations. Skip retired
+            // ones so they never reach the luft.jetzt database.
+            if (!empty($stationData[self::FIELD_ACTIVE_TO])) {
                 continue;
             }
 

--- a/src/StationManager/StationManager.php
+++ b/src/StationManager/StationManager.php
@@ -3,6 +3,7 @@
 namespace App\StationManager;
 
 use App\StationCache\StationCacheInterface;
+use App\StationLoader\StationLoader;
 use Caldera\LuftApiBundle\Api\StationApiInterface;
 use Caldera\LuftModel\Model\Station;
 
@@ -19,7 +20,7 @@ class StationManager implements StationManagerInterface
     /** @return list<Station> */
     public function loadStationList(): array
     {
-        return $this->stationApi->getStations('uba_de');
+        return $this->stationApi->getStations(StationLoader::PROVIDER_IDENTIFIER);
     }
 
     /** @param list<Station> $stationList */

--- a/tests/Command/StationLoadCommandTest.php
+++ b/tests/Command/StationLoadCommandTest.php
@@ -77,6 +77,36 @@ class StationLoadCommandTest extends TestCase
         $this->assertStringContainsString('1 changed stations', $tester->getDisplay());
     }
 
+    public function testUpdateOptionEnablesUpdateMode(): void
+    {
+        $loader = $this->createMock(StationLoaderInterface::class);
+        $loader->expects($this->once())
+            ->method('setUpdate')
+            ->with(true)
+            ->willReturnSelf();
+        $loader->method('load')->willReturn(new StationLoadResult());
+
+        $tester = $this->createCommandTester($loader);
+        $tester->execute(['--update' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testUpdateModeDefaultsToDisabled(): void
+    {
+        $loader = $this->createMock(StationLoaderInterface::class);
+        $loader->expects($this->once())
+            ->method('setUpdate')
+            ->with(false)
+            ->willReturnSelf();
+        $loader->method('load')->willReturn(new StationLoadResult());
+
+        $tester = $this->createCommandTester($loader);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
     public function testExecuteWithNoChanges(): void
     {
         $existing = new Station();

--- a/tests/StationLoader/StationLoaderLoadTest.php
+++ b/tests/StationLoader/StationLoaderLoadTest.php
@@ -130,6 +130,22 @@ class StationLoaderLoadTest extends TestCase
         $this->assertCount(0, $result->getNewStationList());
     }
 
+    public function testLoadSkipsInactiveStations(): void
+    {
+        $inactive = $this->createStationData(id: 7, code: 'DEBB007');
+        $inactive[6] = '2021-03-22'; // "active to" date => decommissioned
+
+        $active = $this->createStationData(id: 21, code: 'DEBB021');
+
+        $loader = $this->createLoader([], [$inactive, $active]);
+
+        $result = $loader->load();
+
+        $this->assertCount(1, $result->getNewStationList());
+        $this->assertArrayHasKey('DEBB021', $result->getNewStationList());
+        $this->assertArrayNotHasKey('DEBB007', $result->getNewStationList());
+    }
+
     public function testLoadSkipsStationsWithMissingCodeField(): void
     {
         $stationData = [0 => 1]; // no field index 1


### PR DESCRIPTION
## Summary

Cleans up the `StationLoader` altlast: an unreachable update path, unfiltered import of decommissioned stations, and dead constants/duplicated literals.

## Changes

- **Skip decommissioned stations.** The UBA meta response carries an "active to" field (index 6): `null` for stations in operation, a date for retired ones. `load()` now skips retired stations, so they never reach the luft.jetzt database. Verified live against the current API: ~80 of 525 stations are retired (e.g. `DEBB007` "Elsterwerda", active-to `2021-03-22`), while operating stations have `null`.
- **Make the update path reachable.** `station:load` gains a `--update` option that calls `StationLoader::setUpdate()`. Previously `setUpdate()` was never invoked, so `getChangedStationList()` was always empty and `StationApi::postStations()` a no-op. The path (merge existing station + submit) is already unit-tested; this simply exposes it.
- **Remove dead constants** `FIELD_CITY`, `FIELD_STATE_CODE`, `FIELD_STATE` (never read).
- **De-duplicate the provider literal**: `PROVIDER_IDENTIFIER` now replaces the hard-coded `'uba_de'` in `StationLoader::mergeStation()` and `StationManager`.

## Already resolved on main (not re-done here)

- **The update-branch crash** from the issue (accessing a non-existent `$existingStationList` property → `TypeError`) is already fixed on main: the branch reads `StationLoadResult::getExistingStationList()[$stationCode]`.

## Deliberately not implemented

- **Real change detection** (only submit stations whose fields actually differ). Update mode still marks every existing station as "changed". Implementing a field-level diff against the luft-model `Station` is a larger behavioral change and out of scope for this cleanup; `--update` remains opt-in, so the default `station:load` run is unaffected.
- **`setUpdate(bool $update = false)` default signature.** Left as-is because the interface and existing tests rely on it; the `--update` wiring always passes an explicit boolean, so the odd default is no longer a foot-gun in practice.

## Verification

- `vendor/bin/phpunit` green (71 tests; new tests for inactive-station skipping and the `--update` wiring).
- `vendor/bin/phpstan analyse` → no errors.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)