### PR TITLE
Add HTTP timeouts and remote-data plausibility validation (#51)

### DIFF
--- a/config/packages/http_client.yaml
+++ b/config/packages/http_client.yaml
@@ -1,0 +1,8 @@
+framework:
+    http_client:
+        default_options:
+            # Idle timeout between two data chunks. Prevents a hanging UBA
+            # upstream from blocking the cron job indefinitely.
+            timeout: 10
+            # Hard cap on the whole request/response duration.
+            max_duration: 30

--- a/src/SourceFetcher/Parser/Parser.php
+++ b/src/SourceFetcher/Parser/Parser.php
@@ -8,6 +8,13 @@ use Caldera\LuftModel\Model\Value;
 
 class Parser implements ParserInterface
 {
+    /**
+     * Generous upper sanity bound for a measurement value. Real pollutant
+     * concentrations (µg/m³ or mg/m³) never approach this; anything above it
+     * signals a corrupt reading and is discarded rather than pushed on.
+     */
+    private const MAX_PLAUSIBLE_VALUE = 100000.0;
+
     /** @var array<int, Station> */
     protected array $stationList;
 
@@ -24,7 +31,7 @@ class Parser implements ParserInterface
 
         foreach ($response['data'] as $ubaStationId => $dataSet) {
             while ($data = array_pop($dataSet)) {
-                if ($data[2] <= 0) {
+                if ($data[2] <= 0 || $data[2] > self::MAX_PLAUSIBLE_VALUE) {
                     continue;
                 }
 

--- a/src/StationLoader/StationLoader.php
+++ b/src/StationLoader/StationLoader.php
@@ -40,15 +40,43 @@ class StationLoader implements StationLoaderInterface
         return array_key_exists($stationCode, $stationLoadResult->getNewStationList()) || array_key_exists($stationCode, $stationLoadResult->getChangedStationList()) || array_key_exists($stationCode, $stationLoadResult->getExistingStationList());
     }
 
+    // Bounding box covering Germany (with a small margin). Coordinates outside
+    // this range indicate corrupt UBA meta data and are rejected before the
+    // station is submitted to the luft.jetzt API.
+    private const GERMANY_LATITUDE_MIN = 47.0;
+    private const GERMANY_LATITUDE_MAX = 55.5;
+    private const GERMANY_LONGITUDE_MIN = 5.5;
+    private const GERMANY_LONGITUDE_MAX = 15.5;
+
+    private function assertPlausibleCoordinates(float $latitude, float $longitude, string $stationCode): void
+    {
+        if (
+            $latitude < self::GERMANY_LATITUDE_MIN || $latitude > self::GERMANY_LATITUDE_MAX
+            || $longitude < self::GERMANY_LONGITUDE_MIN || $longitude > self::GERMANY_LONGITUDE_MAX
+        ) {
+            throw new \InvalidArgumentException(sprintf(
+                'Implausible coordinates for station "%s": latitude %s, longitude %s (expected within Germany).',
+                $stationCode,
+                $latitude,
+                $longitude,
+            ));
+        }
+    }
+
     /** @param array<int, mixed> $stationData */
     protected function mergeStation(Station $station, array $stationData): Station
     {
+        $latitude = (float) $stationData[self::FIELD_LATITUDE];
+        $longitude = (float) $stationData[self::FIELD_LONGITUDE];
+
+        $this->assertPlausibleCoordinates($latitude, $longitude, (string) $stationData[self::FIELD_STATION_CODE]);
+
         $station
             ->setTitle($stationData[self::FIELD_TITLE])
             ->setProvider('uba_de')
             ->setStationCode($stationData[self::FIELD_STATION_CODE])
-            ->setLatitude((float)$stationData[self::FIELD_LATITUDE])
-            ->setLongitude((float)$stationData[self::FIELD_LONGITUDE])
+            ->setLatitude($latitude)
+            ->setLongitude($longitude)
             ->setFromDate(new \DateTime($stationData[self::FIELD_START_DATE]))
             ->setStationType($this->mapStationType($stationData[self::FIELD_STATION_TYPE]))
             ->setAreaType($this->mapAreaType($stationData[self::FIELD_AREA_TYPE]))

--- a/tests/SourceFetcher/Parser/ParserTest.php
+++ b/tests/SourceFetcher/Parser/ParserTest.php
@@ -86,6 +86,24 @@ class ParserTest extends TestCase
         $this->assertCount(0, $result);
     }
 
+    public function testParseSkipsImplausiblyLargeValues(): void
+    {
+        $station = $this->createStation();
+        $parser = $this->createParser($this->createStationManager(true, $station));
+
+        $response = json_encode([
+            'data' => [
+                123 => [
+                    [123, 1, 999999.0, '2024-06-15 12:00:00'],
+                ],
+            ],
+        ]);
+
+        $result = $parser->parse($response, 'pm10');
+
+        $this->assertCount(0, $result);
+    }
+
     public function testParseSkipsUnknownStations(): void
     {
         $parser = $this->createParser($this->createStationManager(false));

--- a/tests/StationLoader/StationLoaderLoadTest.php
+++ b/tests/StationLoader/StationLoaderLoadTest.php
@@ -169,6 +169,17 @@ class StationLoaderLoadTest extends TestCase
         $this->assertSame('traffic', $station->getStationType());
     }
 
+    public function testLoadRejectsImplausibleCoordinates(): void
+    {
+        $loader = $this->createLoader([], [
+            $this->createStationData(id: 1, code: 'DEBW001', longitude: 0.0, latitude: 0.0),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $loader->load();
+    }
+
     public function testSetUpdateReturnsSelf(): void
     {
         $loader = $this->createLoader([], []);


### PR DESCRIPTION
## Summary

Delivers the two hardening items from this issue: a missing HTTP timeout and plausibility validation of the remote UBA data before it is pushed to luft.jetzt.

## Changes

- **HTTP timeout.** New `config/packages/http_client.yaml` sets `framework.http_client.default_options.timeout: 10` and `max_duration: 30`. Both `SourceFetcher` and `StationLoader` use the shared autowired client, so a hanging UBA upstream can no longer block the hourly cron job indefinitely.
- **Coordinate validation.** `StationLoader` checks each station's latitude/longitude against a Germany bounding box (with margin) before submitting it; corrupt meta data (e.g. a `0/0` coordinate or swapped values) now raises a clear `InvalidArgumentException` naming the station instead of importing a bogus location.
- **Value validation.** The parser discards measurements above a generous upper sanity bound (`100000`), in addition to the existing `<= 0` filter.

## Already resolved / handled elsewhere

- **Vulnerable Symfony dependencies + `composer audit` in CI** — the lock was pinned to Symfony 8.0.8 (10 advisories). These are cleared and an audit CI gate is added in the **Symfony 8.1 upgrade PR (#54)**. Kept out of this PR to avoid a second, conflicting lockfile change.
- The issue notes that input pollutants are already validated via a `tryFrom` enum, station types via `match()`, and values `<= 0` are already filtered — still true on `main`.

## Verification

- `bin/console debug:config framework http_client` shows `timeout: 10`, `max_duration: 30`.
- `vendor/bin/phpunit` green (70 tests; new tests for the value bound and the coordinate rejection).
- `vendor/bin/phpstan analyse` → no errors.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)